### PR TITLE
Handle contentContainerStyle prop as an array

### DIFF
--- a/lib/KeyboardAwareScrollView.js
+++ b/lib/KeyboardAwareScrollView.js
@@ -36,8 +36,9 @@ const KeyboardAwareScrollView = createReactClass({
     let newContentContainerStyle
 
     if (Platform.OS === 'android' && enableOnAndroid) {
-      newContentContainerStyle = Object.assign({}, contentContainerStyle)
-      newContentContainerStyle.paddingBottom = (newContentContainerStyle.paddingBottom || 0) + keyboardSpace
+      newContentContainerStyle = [].concat(contentContainerStyle).concat({
+        paddingBottom: ((contentContainerStyle || {}).paddingBottom || 0) + keyboardSpace
+      })
     }
 
     return (


### PR DESCRIPTION
The `contentContainerStyle` prop can be an array of StyleSheet references or objects, this prevents an error when this is the case.